### PR TITLE
🔧 ci: Add source_folder parameter for coverage path remapping

### DIFF
--- a/.github/workflows/rw_build_and_test.yaml
+++ b/.github/workflows/rw_build_and_test.yaml
@@ -92,6 +92,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: unit-test
+      source_folder: abe_plugin
 
   integration-test_codecov:
 #    name: For unit test, organize and generate the testing report and upload it to Codecov
@@ -103,6 +104,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: integration-test
+      source_folder: abe_plugin
 
   one_e2e-test_codecov:
 #    name: For end-to-end test, organize and generate the testing report and upload it to Codecov
@@ -114,6 +116,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: e2e-test
+      source_folder: abe_plugin
 
   e2e-test_codecov:
 #    name: For end-to-end test, organize and generate the testing report and upload it to Codecov
@@ -125,6 +128,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: e2e-test
+      source_folder: abe_plugin
 
   contract-test_codecov:
 #    name: For end-to-end test, organize and generate the testing report and upload it to Codecov
@@ -136,6 +140,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: contract-test
+      source_folder: abe_plugin
 
   all_test_codecov:
 #    name: Organize and generate the testing report and upload it to Codecov
@@ -147,3 +152,4 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: all-test
+      source_folder: abe_plugin


### PR DESCRIPTION
## _Target_

Add `source_folder` parameter to coverage organization workflow for correct path remapping.

* ### Task summary:
    Update coverage workflow to use `abe_plugin/` as source folder.

* ### Task tickets:
    * Upstream: GitHub-Action_Reusable_Workflows-Python#156

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 🤖 CI/CD

## _Description_

✅ Correct coverage path mapping for `abe_plugin/` folder